### PR TITLE
fix: missing dependencies not detected, closes #3

### DIFF
--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -50,9 +50,20 @@ const verifyCircularDependencies = <T>(
   }
 }
 
-export const verify = (services: ServiceListMetadata): void => {
+const verifyAllServices = (
+  services: ServiceListMetadata,
+  callback: (
+    identifier: Abstract<unknown>,
+    metadata: ServiceData<unknown>,
+    services: ServiceListMetadata
+  ) => void
+): void => {
   for (const [identifier, metadata] of services) {
-    verifyMetadata(identifier, metadata, services)
-    verifyCircularDependencies(identifier, metadata, services)
+    callback(identifier, metadata, services)
   }
+}
+
+export const verify = (services: ServiceListMetadata): void => {
+  verifyAllServices(services, verifyMetadata)
+  verifyAllServices(services, verifyCircularDependencies)
 }

--- a/test/builder.ts
+++ b/test/builder.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 import tap from 'tap'
 import { ContainerBuilder } from '../src/diod'
-import { Agenda } from './fixtures/agenda'
+import { Agenda, Schedule } from './fixtures/agenda'
 import {
   circular1,
   Circular1,
@@ -55,6 +55,23 @@ void tap.test(
       // Act
       builder.build()
     }, new Error('Service not registered for the following dependencies of Agenda: Clock, Calendar'))
+    t.end()
+  }
+)
+
+void tap.test(
+  'throws error building a container with a registered service which has a dependency with unregistered dependencies',
+  (t) => {
+    // Arrange
+    const builder = new ContainerBuilder()
+    builder.register(Schedule).use(Schedule)
+    builder.register(Agenda).use(Agenda)
+
+    // Assert
+    t.throws(() => {
+      // Act
+      builder.build()
+    }, new Error('Service not registered for the following dependencies of Agenda: Clock'))
     t.end()
   }
 )

--- a/test/fixtures/agenda.ts
+++ b/test/fixtures/agenda.ts
@@ -15,3 +15,8 @@ export class Agenda {
     return `${this.calendar.nowCalendar()}-${this.clock.now()}`
   }
 }
+
+@Service()
+export class Schedule {
+  public constructor(public readonly calendar: Agenda) {}
+}


### PR DESCRIPTION
Existence of all dependencies must be checked before checking circular depencecies.