### PR TITLE
Update broken links from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A very opinionated and lightweight (under 2kB minified and gzipped) inversion of
 These are the reasons that have led me to reinvent the wheel and create DIOD:
 
 - I don't like the string-based solutions that current Typescript dependency injection libraries use to bypass the Typescript compiler's inability to emit Javascript constructs. DIOD autowiring will always be based on constructor typings and property injection will be avoided, even when it implies working with abstract classes instead of interfaces.
-- I don't like to couple my domain or application layers (see [hexagonal architecture](<https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)>)) with a dependency injection library. Despite DIOD providing a decorator for ease of usage, you are encouraged to [create and use your own](./custom-decorator.md) keeping your inner layers free of DIOD.
+- I don't like to couple my domain or application layers (see [hexagonal architecture](<https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)>)) with a dependency injection library. Despite DIOD providing a decorator for ease of usage, you are encouraged to [create and use your own](./docs/custom-decorator.md) keeping your inner layers free of DIOD.
 
 Both reasons are related to some TypeScript constraints: whenever you want to work with type information in runtime (in compiled JS), you inevitably need to use decorators. Even so, you won't be able to have information about interfaces at runtime.
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ A very opinionated and lightweight (under 2kB minified and gzipped) inversion of
 These are the reasons that have led me to reinvent the wheel and create DIOD:
 
 - I don't like the string-based solutions that current Typescript dependency injection libraries use to bypass the Typescript compiler's inability to emit Javascript constructs. DIOD autowiring will always be based on constructor typings and property injection will be avoided, even when it implies working with abstract classes instead of interfaces.
-- I don't like to couple my domain or application layers (see [hexagonal architecture](<https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)>)) with a dependency injection library. Despite DIOD providing a decorator for ease of usage, you are encouraged to [create and use your own](.docs/custom-decorator.md) keeping your inner layers free of DIOD.
+- I don't like to couple my domain or application layers (see [hexagonal architecture](<https://en.wikipedia.org/wiki/Hexagonal_architecture_(software)>)) with a dependency injection library. Despite DIOD providing a decorator for ease of usage, you are encouraged to [create and use your own](./custom-decorator.md) keeping your inner layers free of DIOD.
 
 Both reasons are related to some TypeScript constraints: whenever you want to work with type information in runtime (in compiled JS), you inevitably need to use decorators. Even so, you won't be able to have information about interfaces at runtime.
 
-It might sound ridiculous but [Typescript needs types](https://www.typescriptneedstypes.com).
+It might sound ridiculous but [Typescript needs types](https://github.com/akutruff/typescript-needs-types).
 
 Read [this article in my blog](https://www.albertovarela.net/blog/2021/06/diod-dependency-injection-typescript/) if you want more context about the reasons behind DIOD.
 


### PR DESCRIPTION
### Broken Link 1

- "create and use your own" link is not working:

![1](https://github.com/artberri/diod/assets/19661411/a347473b-69c1-4e13-a266-505a6b65f0e6)

- The broken link is redirecting to a 404 - page not found:

![2](https://github.com/artberri/diod/assets/19661411/d7f4b8da-5848-43a9-9ecb-83d3547e0e10)

- I only had to update the URL to be the correct one, from `.docs/custom-decorator.md`  to `./custom-decorator.md`.

### Broken Link 2

- "TypeScript needs types" link is not working:

![3](https://github.com/artberri/diod/assets/19661411/759af66d-cf0b-4dcc-bca0-19bd3d415250)

- The broken link is resulting in a "We can’t connect to the server at typescriptneedstypes.com." error:

![4](https://github.com/artberri/diod/assets/19661411/4ca86bf8-4acf-4bda-a8aa-27137b9a85c8)

- As the server seems to be unavailable, I updated the URL to https://github.com/akutruff/typescript-needs-types, as it contains the desired information.

### Link to the issue
#13  